### PR TITLE
Docs: Clarify Firebase API key usage and security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # billing-app
+
+## Security Note on Firebase API Key
+
+This project uses Firebase for its backend services. The Firebase configuration, located in `public/js/config.js`, includes an `apiKey`. It's important to understand the nature of this key:
+
+*   **Firebase Web API Keys are Intended to be Public:** Unlike server-side API keys, Firebase Web API keys are designed to be included in client-side code. They identify your Firebase project to Firebase servers.
+*   **Security is Enforced by Firebase Security Rules:** Access to your Firebase data (Firestore, Realtime Database, Storage) is controlled by Firebase Security Rules, which you must configure carefully. The API key itself does not grant direct access to your data.
+*   **Restricting Your API Key:** While the key is public, you **must** restrict its usage in the Google Cloud Console. This helps prevent unauthorized use of your Firebase project by other applications. Key restrictions can include:
+    *   **HTTP referrers:** Restrict the key to be used only from your application's domains.
+    *   **API restrictions:** Limit the key to only be able to call the specific Firebase services your application needs.
+*   **Regular Review and Rotation:**
+    *   Regularly review the permissions associated with this key in the Google Cloud Console.
+    *   If you suspect your key has been compromised or was previously unrestricted, you should rotate it: generate a new key in the Firebase console, update it in `public/js/config.js`, and delete the old key.
+
+The security alert regarding an "exposed Google API Key" likely refers to the Firebase `apiKey`. By following the practices above, you can ensure your Firebase project remains secure. Always refer to the [official Firebase documentation](https://firebase.google.com/docs/projects/api-keys) for the most up-to-date security best practices.

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -1,4 +1,15 @@
 
+// IMPORTANT NOTE ON API KEY SECURITY:
+// The apiKey below is a Firebase Web API key. These keys are designed to be public and are necessary for the Firebase SDK to interact with your Firebase project on the client-side.
+// Firebase secures your data primarily through Firebase Security Rules (e.g., in firestore.rules), not by keeping this apiKey secret.
+//
+// HOWEVER, IT IS CRUCIAL TO:
+// 1. Ensure this API key is restricted in the Google Cloud Console to prevent unauthorized use. It should only be allowed to be used from your authorized domains.
+// 2. Regularly review the permissions associated with this key in the Google Cloud Console to ensure it only has the minimum necessary access.
+// 3. If there's any doubt about previous exposure or if the key had overly permissive settings, consider rotating the key (generate a new one in Firebase console and update it here) and revoking the old one.
+//
+// The issue regarding an "exposed Google API Key" likely refers to this key. While it's exposed by design for Firebase web apps, the responsibility lies with the project admin to ensure it's properly restricted.
+
 // Your web app's Firebase configuration
 const firebaseConfig = {
   apiKey: "AIzaSyB68jUbHK-r-zs3RBsv8Dfjq05GIlNq6C4",


### PR DESCRIPTION
The API key in public/js/config.js is a Firebase Web API key, which is intended for client-side use. This commit adds:

- A comment in public/js/config.js explaining the nature of the key and emphasizing the need for restrictions in Google Cloud Console.
- A new section in README.md detailing Firebase API key security, best practices for restriction, and rotation.

These changes address security concerns by educating you on how Firebase API keys work and the steps required to secure them at the Google Cloud project level. It also reminds you to rotate the key if its security is in doubt.